### PR TITLE
Fix timestamp

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ var (
 
 const METADATA_TEMPLATE = `{
     "deleted": false,
-    "lastModified": "%d",
+    "lastModified": "%d000",
     "metadatamodified": true,
     "modified": true,
     "parent": "",


### PR DESCRIPTION
The ordering in my remarkable was incorrect. With this the printed document gets sorted correctly when sorted by Last Updated.

btw: Cool work @Evidlo, this is a really usefully tool  :+1: 

---


The timestamp is in miliseconds, not seconds, add three zeros' to ensure
correct ordering.

Before the metadata contained:

    "lastModified": "1583919213",

now it contains:

    "lastModified": "1583919213000",

found this out by looking at

    cat /home/root/.local/share/remarkable/xochitl/*.metadata | grep lastModified