### PR TITLE
fix insall script on mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,10 @@ download_prebuilt:
 .PHONY: install
 install: printer.arm
 	ssh-add
-	ssh root@$(host) systemctl stop printer
+	ssh root@$(host) systemctl stop printer 2>&1 >/dev/null
 	scp printer.arm root@$(host):
 	scp printer.service root@$(host):/etc/systemd/system
-	ssh root@$(host) <<- ENDSSH
-		systemctl daemon-reload
-		systemctl enable printer
-		systemctl restart printer
-	ENDSSH
+	ssh root@$(host) 'systemctl daemon-reload && systemctl enable printer && systemctl restart printer'
 
 .PHONY: release
 release: printer.arm printer.x86

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,10 @@ download_prebuilt:
 .PHONY: install
 install: printer.arm
 	ssh-add
-	ssh root@$(host) systemctl stop printer 2>&1 >/dev/null
+	if ssh root@$(host) systemctl is-active --quiet printer;
+	then
+	    [stop service]
+	fi
 	scp printer.arm root@$(host):
 	scp printer.service root@$(host):/etc/systemd/system
 	ssh root@$(host) 'systemctl daemon-reload && systemctl enable printer && systemctl restart printer'

--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,13 @@ download_prebuilt:
 # install to device
 .PHONY: install
 install: printer.arm
-	ssh-add
-	if ssh root@$(host) systemctl is-active --quiet printer;
-	then
-	    [stop service]
-	fi
+	eval $(shell ssh-agent -s)
+	ssh -o AddKeysToAgent=yes root@$(host) systemctl stop printer || true
 	scp printer.arm root@$(host):
 	scp printer.service root@$(host):/etc/systemd/system
-	ssh root@$(host) 'systemctl daemon-reload && systemctl enable printer && systemctl restart printer'
+	ssh root@$(host) systemctl daemon-reload
+	ssh root@$(host) systemctl enable printer
+	ssh root@$(host) systemctl restart printer
 
 .PHONY: release
 release: printer.arm printer.x86

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ printer.x86:
 # get latest prebuilt releases
 .PHONY: download_prebuilt
 download_prebuilt:
-	wget http://github.com/evidlo/remarkable_printer/releases/latest/download/release.zip
+	curl -LO http://github.com/evidlo/remarkable_printer/releases/latest/download/release.zip
 	unzip release.zip
 
 # install to device


### PR DESCRIPTION
This changes fix installation issues on mac, specifically:

- `systemctl stop printer` used to error on remarkable after last software update (presumable because service was no there), so here we ignore that error.
- I kept getting `Pseudo-terminal will not be allocated because stdin is not a terminal.` on line 27. I was unable to figure out to get it work in any other way.