### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
-mkdir -p /home/root/bin
-cd /home/root/bin
+mkdir -p /home/root
+cd /home/root
 wget -O release.zip http://github.com/evidlo/remarkable_printer/releases/latest/download/release.zip
 unzip -o release.zip
 mv printer.service /etc/systemd/system

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
-mkdir -p /home/root
-cd /home/root
+mkdir -p /home/root/bin
+cd /home/root/bin
 wget -O release.zip http://github.com/evidlo/remarkable_printer/releases/latest/download/release.zip
 unzip -o release.zip
 mv printer.service /etc/systemd/system

--- a/printer.service
+++ b/printer.service
@@ -2,7 +2,7 @@
 Description=Native printing to reMarkable
 
 [Service]
-ExecStart=/home/root/printer.arm -restart -debug
+ExecStart=/home/root/bin/printer.arm -restart -debug
 Restart=always
 
 [Install]


### PR DESCRIPTION
printer.services looks for printer.arm in /home/root and not /home/root/bin. First look showed that the makefile also places printer.arm in /home/root and not in /home/root/bin. This way install.sh should provide a working environment.