### PR TITLE
socket-activate printer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,15 @@ install: printer.arm
 	ssh -o AddKeysToAgent=yes root@$(host) systemctl stop printer || true
 	scp printer.arm root@$(host):
 	scp printer.service root@$(host):/etc/systemd/system
+	scp printer.socket root@$(host):/etc/systemd/system
 	ssh root@$(host) systemctl daemon-reload
-	ssh root@$(host) systemctl enable printer
-	ssh root@$(host) systemctl restart printer
+	ssh root@$(host) systemctl enable printer.socket
+	ssh root@$(host) systemctl restart printer.socket
 
 .PHONY: release
 release: printer.arm printer.x86
 	rm -f release.zip
-	zip release.zip printer.arm printer.x86 printer.service -r
+	zip release.zip printer.arm printer.x86 printer.service printer.socket -r
 
 .PHONY: install_config
 install_config:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ No authentication, so keep WiFi off while not in use.
 
 Virtually all network printers accept raw Postscript/PDF data on TCP port 9100 via the Appsocket/HP Jetdirect protocol.  Sometimes this data is preceded by a few plaintext lines telling the printer information such as the print job name and print settings.
 
-This script simply listens on TCP 9100 and waits for a PDF header, then begins saving data to a pdf file (while also creating the accompanying .metadata file).  The output filename is extracted from the print job name line, if it exists.
+This setup simply listens on TCP 9100 and upon data sent waits for a PDF header, then begins saving data to a pdf file (while also creating the accompanying .metadata file) and then exits again, waiting for the next connection on the port to repeat the procedure.  The output filename is extracted from the print job name line, if it exists.
 
 ## Testing on host
 

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@ cd /home/root/bin
 wget -O release.zip http://github.com/evidlo/remarkable_printer/releases/latest/download/release.zip
 unzip -o release.zip
 mv printer.service /etc/systemd/system
+mv printer.socket /etc/systemd/system
 systemctl daemon-reload
-systemctl enable --now printer.service
+systemctl enable --now printer.socket
 rm printer.x86 release.zip

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 systemctl stop printer.service || true
+systemctl stop printer.socket || true
 mkdir -p /home/root/bin
 cd /home/root/bin
 wget -O release.zip http://github.com/evidlo/remarkable_printer/releases/latest/download/release.zip

--- a/main.go
+++ b/main.go
@@ -4,22 +4,23 @@
 package main
 
 import (
+	"bufio"
+	"flag"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
-	"bufio"
 	"strings"
-	"io"
-	"flag"
-	"github.com/google/uuid"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 var (
-	CONN_HOST = "0.0.0.0"
-	CONN_PORT = "9100"
-	LOG_LEVEL = "error"
+	CONN_HOST   = "0.0.0.0"
+	CONN_PORT   = "9100"
+	LOG_LEVEL   = "error"
 	XOCHITL_DIR = "/home/root/.local/share/remarkable/xochitl/"
 )
 
@@ -37,6 +38,11 @@ const METADATA_TEMPLATE = `{
 }
 `
 
+//const CONTENT_TEMPLATE = `{
+//    "fileType": "pdf"
+//}
+//`
+const CONTENT_TEMPLATE = "{}"
 
 func main() {
 
@@ -96,7 +102,6 @@ func check(e error) {
 		panic(e)
 	}
 }
-
 
 // Handles incoming requests.
 func handleRequest(conn net.Conn) {
@@ -158,6 +163,14 @@ func handleRequest(conn net.Conn) {
 	fmt.Println("Saving metadata to", meta_path)
 	f, err = os.Create(meta_path)
 	f.WriteString(fmt.Sprintf(METADATA_TEMPLATE, time.Now().Unix(), title))
+	f.Close()
+
+	// ----- Create .content -----
+
+	cont_path := XOCHITL_DIR + u.String() + ".content"
+	fmt.Println("Saving content file to", cont_path)
+	f, err = os.Create(cont_path)
+	f.WriteString(fmt.Sprintf(CONTENT_TEMPLATE))
 	f.Close()
 
 	conn.Close()

--- a/main.go
+++ b/main.go
@@ -88,19 +88,8 @@ func main() {
 		}
 		handleRequest(conn)
 
-		// Restart xochitl
 		if *restart {
-			services := []string{"xochitl", "remux", "tarnish", "draft"}
-			for _, service := range services {
-				_, exitcode := exec.Command("systemctl", "is-active", service).CombinedOutput()
-				if exitcode == nil {
-					debug("Restarting " + service)
-					stdout, err := exec.Command("systemctl", "restart", service).CombinedOutput()
-					if err != nil {
-						fmt.Println(service+" restart failed with message:", string(stdout))
-					}
-				}
-			}
+			restartUISoftware()
 		}
 
 		if isSocketActivated {
@@ -197,4 +186,19 @@ func handleRequest(conn net.Conn) {
 	f.Close()
 
 	conn.Close()
+}
+
+// Restarts xochitl or other UI software
+func restartUISoftware() {
+	services := []string{"xochitl", "remux", "tarnish", "draft"}
+	for _, service := range services {
+		_, exitcode := exec.Command("systemctl", "is-active", service).CombinedOutput()
+		if exitcode == nil {
+			debug("Restarting " + service)
+			stdout, err := exec.Command("systemctl", "restart", service).CombinedOutput()
+			if err != nil {
+				fmt.Println(service+" restart failed with message:", string(stdout))
+			}
+		}
+	}
 }

--- a/main.go
+++ b/main.go
@@ -69,7 +69,8 @@ func main() {
 
 	var l net.Listener
 	var err error
-	if os.Getenv("LISTEN_PID") == strconv.Itoa(os.Getpid()) {
+	var isSocketActivated = os.Getenv("LISTEN_PID") == strconv.Itoa(os.Getpid())
+	if isSocketActivated {
 		l, err = net.FileListener(os.NewFile(3, "systemd-socket"))
 	} else {
 		l, err = net.Listen("tcp", *CONN_HOST+":"+*CONN_PORT)
@@ -100,6 +101,10 @@ func main() {
 					}
 				}
 			}
+		}
+
+		if isSocketActivated {
+			break
 		}
 
 	}

--- a/main.go
+++ b/main.go
@@ -60,32 +60,30 @@ func main() {
 	// ----- Listen for connections -----
 
 	// Listen for incoming connections.
-	l, err := net.Listen("tcp", *CONN_HOST + ":" + *CONN_PORT)
+	l, err := net.FileListener(os.NewFile(3, "systemd-socket"))
 	check(err)
 	defer l.Close()
 
 	// Close the listener when the application closes.
 	fmt.Println("Listening on " + *CONN_HOST + ":" + *CONN_PORT)
-	for {
-		// Listen for an incoming connection.
-		conn, err := l.Accept()
-		if err != nil {
-			fmt.Println("Error accepting: ", err.Error())
-			os.Exit(1)
-		}
-		handleRequest(conn)
 
-		// Restart xochitl
-		if *restart {
-			stdout, err := exec.Command("systemctl", "restart", "xochitl").CombinedOutput()
-			if err != nil {
-				fmt.Println("xochitl restart failed with message:", string(stdout))
-			}
-		}
-
+	// Listen for an incoming connection.
+	conn, err := l.Accept()
+	if err != nil {
+		fmt.Println("Error accepting: ", err.Error())
+		os.Exit(1)
 	}
-}
+	handleRequest(conn)
 
+	// Restart xochitl
+	if *restart {
+		stdout, err := exec.Command("systemctl", "restart", "xochitl").CombinedOutput()
+		if err != nil {
+			fmt.Println("xochitl restart failed with message:", string(stdout))
+		}
+	}
+
+}
 
 func debug(msg ...string) {
 	if LOG_LEVEL == "debug" {

--- a/main.go
+++ b/main.go
@@ -73,15 +73,7 @@ func main() {
 	if isSocketActivated {
 		l, err = net.FileListener(os.NewFile(3, "systemd-socket"))
 		fmt.Println("Listening on systemd-socket")
-	} else {
-		l, err = net.Listen("tcp", *CONN_HOST+":"+*CONN_PORT)
-		fmt.Println("Listening on " + *CONN_HOST + ":" + *CONN_PORT)
-	}
-	check(err)
-	defer l.Close() // Close the listener when the application closes.
 
-	for {
-		// Listen for an incoming connection.
 		conn, err := l.Accept()
 		if err != nil {
 			fmt.Println("Error accepting: ", err.Error())
@@ -93,11 +85,28 @@ func main() {
 			restartUISoftware()
 		}
 
-		if isSocketActivated {
-			break
-		}
+	} else {
+		l, err = net.Listen("tcp", *CONN_HOST+":"+*CONN_PORT)
+		fmt.Println("Listening on " + *CONN_HOST + ":" + *CONN_PORT)
 
+		for {
+			// Listen for an incoming connection.
+			conn, err := l.Accept()
+			if err != nil {
+				fmt.Println("Error accepting: ", err.Error())
+				os.Exit(1)
+			}
+			handleRequest(conn)
+
+			if *restart {
+				restartUISoftware()
+			}
+
+		}
 	}
+	check(err)
+	defer l.Close() // Close the listener when the application closes.
+
 }
 
 func debug(msg ...string) {

--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ func main() {
 	var isSocketActivated = os.Getenv("LISTEN_PID") == strconv.Itoa(os.Getpid())
 	if isSocketActivated {
 		l, err = net.FileListener(os.NewFile(3, "systemd-socket"))
+		fmt.Println("Listening on systemd-socket")
 	} else {
 		l, err = net.Listen("tcp", *CONN_HOST+":"+*CONN_PORT)
 		fmt.Println("Listening on " + *CONN_HOST + ":" + *CONN_PORT)

--- a/printer.service
+++ b/printer.service
@@ -1,9 +1,6 @@
 [Unit]
 Description=Native printing to reMarkable
+Requires=printer.socket
 
 [Service]
 ExecStart=/home/root/printer.arm -restart -debug
-Restart=always
-
-[Install]
-WantedBy=multi-user.target

--- a/printer.service
+++ b/printer.service
@@ -4,6 +4,3 @@ Requires=printer.socket
 
 [Service]
 ExecStart=/home/root/bin/printer.arm -restart -debug
-
-[Install]
-WantedBy=multi-user.target

--- a/printer.service
+++ b/printer.service
@@ -4,7 +4,6 @@ Requires=printer.socket
 
 [Service]
 ExecStart=/home/root/bin/printer.arm -restart -debug
-Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/printer.socket
+++ b/printer.socket
@@ -3,7 +3,7 @@ Description=Socket for native printing to reMarkable
 After=multi-user.target
 
 [Socket]
-ListenStream=10.11.99.1:9100
+ListenStream=0.0.0.0:9100
 
 [Install]
 WantedBy=multi-user.target

--- a/printer.socket
+++ b/printer.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=Socket for native printing to reMarkable
+After=multi-user.target
+
+[Socket]
+ListenStream=10.11.99.1:9100
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Previous to this PR, the printer needs to continuously run in the background, even if it doesn't do much most of the time, to keep the socket open and handle incoming connections. This commit hands over handling the open socket to systemd and the printer-code gets started by systemd only when there is something incoming on the socket. The printer itself then takes over the socket from systemd, handles the incoming data and exits afterwards, returning socket management to systemd again.

This reduces running processes as well as the memory footprint of the running system. Both seems not strictly necessary, given the performance characteristics at least of the reMarkable 2, but if every single software takes the "but I'm so small"-approach, the effect cumulates, so I do see a clear benefit in everyone being a good citizen and not clogging resources that are not required for operation. After all, the remarkable has systemd, so I don't see a reason why we shoudn't leverage its features.

The disadvantage of the current code is that you are no longer able to run the code standalone. If you prefer, though, I can change that so that both socket activation as well as standalone-operation is supported. I have abstained to do so in the current state of the code to save that one conditional as well as even simplifying the code by removing one loop that we no longer need when using systemd socket activation.