### PR TITLE
add an additional .content file, see issue #23

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,11 @@ const METADATA_TEMPLATE = `{
 }
 `
 
+const CONTENT_TEMPLATE = `{
+    "fileType": "pdf"
+}
+`
+
 
 func main() {
 
@@ -169,6 +174,14 @@ func handleRequest(conn net.Conn) {
 	fmt.Println("Saving metadata to", meta_path)
 	f, err = os.Create(meta_path)
 	f.WriteString(fmt.Sprintf(METADATA_TEMPLATE, time.Now().Unix(), title))
+	f.Close()
+
+	// ----- Create .content -----
+
+	cont_path := XOCHITL_DIR + u.String() + ".content"
+	fmt.Println("Saving content file to", cont_path)
+	f, err = os.Create(cont_path)
+	f.WriteString(fmt.Sprintf(CONTENT_TEMPLATE))
 	f.Close()
 
 	conn.Close()

--- a/remarkable.ppd
+++ b/remarkable.ppd
@@ -40,7 +40,7 @@
 *JCLToPDFInterpreter: "@PJL ENTER LANGUAGE = PDF<0A>"
 *JCLEnd:              "<1B>%-12345X@PJL EOJ <0A><1B>%-12345X"
 *cupsFilter: "application/vnd.cups-pdf 0 -"
-*cupsFilter2: "application/pdf application/vnd.cups-pdf 0 pdftopdf"
+*cupsFilter2: "application/pdf application/vnd.cups-pdf 0 -"
 
 *OpenGroup: General/General
 *JCLOpenUI *PageSize/Page Size: PickOne


### PR DESCRIPTION
As discussed in https://github.com/Evidlo/remarkable_printer/issues/23, there is an additional .content file whixh needs to be created in recent versions of reMarkable firmware.