### PR TITLE
Add metadata for v3 software

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/Evidlo/remarkable_printer
+
+go 1.18
+
+require github.com/google/uuid v1.3.0

--- a/main.go
+++ b/main.go
@@ -26,6 +26,8 @@ var (
 const METADATA_TEMPLATE = `{
     "deleted": false,
     "lastModified": "%d000",
+    "lastOpened": "0",
+    "lastOpenedPage": 0,
     "metadatamodified": true,
     "modified": true,
     "parent": "",


### PR DESCRIPTION
The latest version of the reMarkable OS (v3) has more metadata fields which are required. If they do not exist, the file can't be opened. This PR simply adds the two extra fields.